### PR TITLE
ci: add PDF build

### DIFF
--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -2,6 +2,7 @@ name: Build RCM-DX PDF
 
 on:
   pull_request:
+    types: [opened, reopened]
   push:
     branches:
       - main

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -3,6 +3,9 @@ name: Build RCM-DX PDF
 on:
   pull_request:
   push:
+    tags:
+      - 'v*.*.*'
+
 
 jobs:
   make-pdf:
@@ -37,6 +40,14 @@ jobs:
           options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION=${{ steps.latest-release.outputs.release }}-draft --env IS_DRAFT=true
           run: make pdf
         if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Build PDF (Release)
+        uses: addnab/docker-run-action@v3
+        with:
+          image: rcm-dx-specification:latest
+          options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION=${{ github.ref_name }}
+          run: make pdf
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
       - name: Upload PDF
         uses: actions/upload-artifact@v4

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -3,6 +3,8 @@ name: Build RCM-DX PDF
 on:
   pull_request:
   push:
+    branches:
+      - main
     tags:
       - 'v*.*.*'
 
@@ -31,15 +33,15 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@v0.8.0
         with:
           repository: openRailAssociation/rcm-dx
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && github.ref_name == 'main'}}
 
-      - name: Build PDF (PR)
+      - name: Build PDF (PR/Preview)
         uses: addnab/docker-run-action@v3
         with:
           image: rcm-dx-specification:latest
           options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION=${{ steps.latest-release.outputs.release }}-draft --env IS_DRAFT=true
           run: make pdf
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && github.ref_name == 'main'}}
 
       - name: Build PDF (Release)
         uses: addnab/docker-run-action@v3

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -1,6 +1,7 @@
 name: Build RCM-DX PDF
 
 on:
+  pull_request:
   push:
 
 jobs:
@@ -22,12 +23,20 @@ jobs:
           load: true
           tags: rcm-dx-specification:latest
 
-      - name: Build PDF
+      - name: Get latest release
+        id: latest-release
+        uses: pozetroninc/github-action-get-latest-release@v0.8.0
+        with:
+          repository: openRailAssociation/rcm-dx
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Build PDF (PR)
         uses: addnab/docker-run-action@v3
         with:
           image: rcm-dx-specification:latest
-          options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION=v2.0.5-draft --env IS_DRAFT=true
+          options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION=${{ steps.latest-release.outputs.release }}-draft --env IS_DRAFT=true
           run: make pdf
+        if: ${{ github.event_name == 'pull_request' }}
 
       - name: Upload PDF
         uses: actions/upload-artifact@v4

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -29,6 +29,9 @@ jobs:
           load: true
           tags: rcm-dx-specification:latest
 
+      # We use this job to get the version number from the latest release. This
+      # is currently only used to automate the definition of the draft version
+      # in the PR/Preview build jobs.
       - name: Get latest release
         id: latest-release
         uses: pozetroninc/github-action-get-latest-release@v0.8.0
@@ -36,6 +39,8 @@ jobs:
           repository: openRailAssociation/rcm-dx
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && github.ref_name == 'main'}}
 
+      # This job is being executed for pull requests to provide a PDF preview
+      # and on main after the changes have been merged.
       - name: Build PDF (PR/Preview)
         uses: addnab/docker-run-action@v3
         with:
@@ -44,6 +49,8 @@ jobs:
           run: make pdf
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && github.ref_name == 'main'}}
 
+      # This job is being executed after a release has been tagged. The built
+      # PDF will later on manually be added as an asset to the release.
       - name: Build PDF (Release)
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -20,9 +20,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -2,7 +2,10 @@ name: Build RCM-DX PDF
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types:
+      - opened
+      - reopened
+      - synchronize
   push:
     branches:
       - main

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -1,0 +1,37 @@
+name: Build RCM-DX PDF
+
+on:
+  push:
+
+jobs:
+  make-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          tags: rcm-dx-specification:latest
+
+      - name: Build PDF
+        uses: addnab/docker-run-action@v3
+        with:
+          image: rcm-dx-specification:latest
+          options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION=v2.0.5-draft --env IS_DRAFT=true
+          run: make pdf
+
+      - name: Upload PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: RCM-DX-Specification_EN_draft
+          path: generated-specs/pdf/RCM-DX-Specification_EN.pdf
+          if-no-files-found: error

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -54,6 +54,6 @@ jobs:
       - name: Upload PDF
         uses: actions/upload-artifact@v4
         with:
-          name: RCM-DX-Specification_EN_draft
+          name: RCM-DX-Specification_EN
           path: generated-specs/pdf/RCM-DX-Specification_EN.pdf
           if-no-files-found: error

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apk add --no-cache \
 
 WORKDIR /data
 
-ENTRYPOINT /bin/sh
+ENTRYPOINT ["/bin/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/extra:3.6.4.0
+FROM pandoc/extra:3.7
 
 RUN apk add --no-cache \
   envsubst \

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,27 @@
 # Releases
 
 After reviews are completed and changes are approved by the committee, a new release will be issued. Due to the project being stable, releases will be infrequent.
+
+## Release process
+
+The PDF version of the specification will automatically be built when a new release is being tagged.
+To tag a new release follow these steps:
+
+1. Open the new release page: https://github.com/OpenRailAssociation/rcm-dx/releases/new
+2. Click on "Tag: Select tag"
+3. Click on "Create new tag"
+4. Enter the version with `v` as a prefix, e.g. `v2.0.5` and click on "Create"
+5. Add a title for the release
+6. Describe the changes which are part of this release
+7. Ensure that the "Set as the latest release" checkbox is activated
+8. Click in "Publish release"
+
+To add the PDF to the release afterwards follow these steps:
+
+1. Open the Actions tab: https://github.com/OpenRailAssociation/rcm-dx/actions
+2. Click on the most recent worflow run and scroll to the bottom of the page to "Artifacts"
+3. Download the "RCM-DX-Specification_EN" artifact
+4. Unpack the ZIP and extract the file `RCM-DX-Specification_EN.pdf`
+5. Open the release you created previously and press the edit button (🖉)
+6. Add the PDF as an asset to the release
+7. Press the "Update release" button


### PR DESCRIPTION
- Add GitHub workflows to build PDF for pull requests and on tags
- Document the release process

We might have to update the release instructions after we tested the process once.