### PR TITLE
ci: build PDF to GitHub pages

### DIFF
--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -1,4 +1,4 @@
-name: Build RCM-DX PDF
+name: Build documentation
 
 on:
   pull_request:
@@ -12,10 +12,17 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions: {}
 
 jobs:
   make-pdf:
+    name: "Build RCM-DX PDF"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # read repository contents
+      id-token: write # to verify the deployment originates from an appropriate source (required for action/deploy-pages)
+      pages: write # to allow a deployment to GitHub Pages
+      artifact-metadata: write # required to upload generated PDF as an artifact
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -73,3 +73,13 @@ jobs:
           path: generated-specs/pdf/RCM-DX-Specification_EN.pdf
           if-no-files-found: error
           archive: false
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: generated-specs/pdf
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # read repository contents
-      id-token: write # to verify the deployment originates from an appropriate source (required for action/deploy-pages)
-      pages: write # to allow a deployment to GitHub Pages
       artifact-metadata: write # required to upload generated PDF as an artifact
+    outputs:
+      pdf-artifact-id: ${{ steps.upload-pdf-artifact.outputs.artifact-id }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -67,6 +67,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
       - name: Upload PDF
+        id: upload-pdf-artifact
         uses: actions/upload-artifact@v7
         with:
           name: RCM-DX-Specification_EN
@@ -74,12 +75,30 @@ jobs:
           if-no-files-found: error
           archive: false
 
+  github-pages:
+    name: "Upload to GitHub Pages"
+    runs-on: ubuntu-latest
+    needs: make-pdf
+    permissions:
+      id-token: write # to verify the deployment originates from an appropriate source (required for action/deploy-pages)
+      pages: write # to allow a deployment to GitHub Pages
+      artifact-metadata: read # required to download generated PDF from an artifact
+    #if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+    if: ${{ github.event_name == 'push' && github.ref_name == 'ci/build_pdf_to_pages' }}
+    steps:
+      - name: Download PDF artifact
+        uses: actions/download-artifact@v8
+        with:
+          artifact-ids: ${{ needs.make-pdf.outputs.pdf-artifact-id }}
+
       - name: Setup Pages
         uses: actions/configure-pages@v6
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: generated-specs/pdf
+          path: .
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -2,10 +2,8 @@ name: Build documentation
 
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -41,10 +41,26 @@ jobs:
       # in the PR/Preview build jobs.
       - name: Get latest release
         id: latest-release
-        uses: pozetroninc/github-action-get-latest-release@v0.8.0
+        uses: actions/github-script@v9
         with:
-          repository: openRailAssociation/rcm-dx
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && github.ref_name == 'main'}}
+          result-encoding: string
+          script: |
+            var releases  = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            releases = releases.data;
+            // Filter out draft and prerelease releases
+            releases = releases.filter(x => x.draft != true);
+            releases = releases.filter(x => x.prerelease != true);
+            if (releases.length) {
+              console.log(`Found ${releases[0].tag_name} as the latest release`)
+              return releases[0].tag_name;
+            } else {
+              console.log("No valid releases found");
+              return null
+            }
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && github.ref_name == 'main' }}
 
       # This job is being executed for pull requests to provide a PDF preview
       # and on main after the changes have been merged.
@@ -54,7 +70,7 @@ jobs:
           image: rcm-dx-specification:latest
           options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION="${{ steps.latest-release.outputs.release }}-dev Commit ID ${{ github.sha }}"
           run: make pdf
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && github.ref_name == 'main'}}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && github.ref_name == 'main' }}
 
       # This job is being executed after a release has been tagged. The built
       # PDF will later on manually be added as an asset to the release.

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -59,21 +59,13 @@ jobs:
       # This job is being executed for pull requests to provide a PDF preview
       # and on main after the changes have been merged.
       - name: Build PDF (PR/Preview)
-        uses: addnab/docker-run-action@v3
-        with:
-          image: rcm-dx-specification:latest
-          options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION="${{ steps.latest-release.outputs.release }}-dev Commit ID ${{ github.sha }}"
-          run: make pdf
+        run: docker run --volume ${{ github.workspace }}:/data --env SPEC_VERSION="${{ steps.latest-release.outputs.result }}-dev Commit ID ${{ github.sha }}" rcm-dx-specification:latest
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && github.ref_name == 'main' }}
 
       # This job is being executed after a release has been tagged. The built
       # PDF will later on manually be added as an asset to the release.
       - name: Build PDF (Release)
-        uses: addnab/docker-run-action@v3
-        with:
-          image: rcm-dx-specification:latest
-          options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION=${{ github.ref_name }}
-          run: make pdf
+        run: docker run --volume ${{ github.workspace }}:/data --env SPEC_VERSION=${{ github.ref_name }} rcm-dx-specification:latest
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
       - name: Upload PDF

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: rcm-dx-specification:latest
-          options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION=${{ steps.latest-release.outputs.release }}-draft --env IS_DRAFT=true
+          options: --volume ${{ github.workspace }}:/data --env SPEC_VERSION="${{ steps.latest-release.outputs.release }}-dev Commit ID ${{ github.sha }}"
           run: make pdf
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && github.ref_name == 'main'}}
 

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -27,14 +27,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Build Docker image
-        uses: docker/build-push-action@v7
-        with:
-          load: true
-          tags: rcm-dx-specification:latest
+        run: docker build -t rcm-dx-specification:latest .
 
       # We use this job to get the version number from the latest release. This
       # is currently only used to automate the definition of the draft version

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apk add --no-cache \
 
 WORKDIR /data
 
-ENTRYPOINT ["/bin/sh"]
+ENTRYPOINT ["make", "pdf"]

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,12 @@
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort -k 1,1 | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: images
-images: ## generate images using plantuml
+images: images/*.puml ## generate images using plantuml
 	java -DPLANTUML_LIMIT_SIZE=8192 -jar /usr/share/java/plantuml.jar ./images/rcm-dx-images.puml -o generated
 	mkdir -p generated-specs/html/images
 	cp -r images/* generated-specs/html/images/
 
-.PHONY: pdf
-pdf: images ## generate PDF specification
+pdf: RCM-DX-Specification_EN.md images ## generate PDF specification
 	mkdir -p generated-specs/pdf
 	envsubst < metadata.md > _metadata.md
 ifeq ($(IS_DRAFT),true)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The specification is available in two formats:
 
 - Markdown: [RCM-DX-Specification_EN.md](RCM-DX-Specification_EN.md)
-- PDF: [RCM-DX-Specification_EN.pdf](https://github.com/OpenRailAssociation/rcm-dx/releases/latest/download/RCM-DX-Specification_EN.pdf)
+- PDF: [RCM-DX-Specification_EN.pdf](https://openrailassociation.github.io/rcm-dx/RCM-DX-Specification_EN.pdf)
 
 ## Motivation
 


### PR DESCRIPTION
The goal of this PR is to upload a PDF with all the changes in `main` to GitHub pages.

To ensure that pre-release PDFs can be distinguished from release PDFs string, draft is still present in pre-release PDF builds.